### PR TITLE
Add support for schema-qualified object names in parsed objects

### DIFF
--- a/lib/pg_objects/db_object.rb
+++ b/lib/pg_objects/db_object.rb
@@ -4,6 +4,8 @@
 # [name]  name of file without extension
 # [full_name] full pathname of file
 # [object_name] name of function, trigger etc. if it was successfully parsed, otherwise - nil
+# [qualified_object_name] schema-qualified object name (+schema.name+) when a schema is
+#   present, otherwise same as object_name; nil if parsing failed
 class PgObjects::DbObject
   include Memery
 

--- a/lib/pg_objects/db_object.rb
+++ b/lib/pg_objects/db_object.rb
@@ -10,7 +10,7 @@ class PgObjects::DbObject
   include Import['parser']
 
   attr_accessor :status
-  attr_reader :full_name, :object_name
+  attr_reader :full_name, :object_name, :qualified_object_name
 
   def initialize(path, status = :new, parser:)
     @full_name = path
@@ -21,6 +21,7 @@ class PgObjects::DbObject
   def create
     parser.load(sql_query)
     @object_name = parser.fetch_object_name
+    @qualified_object_name = parser.fetch_qualified_object_name
     @status = :pending
 
     self

--- a/lib/pg_objects/manager.rb
+++ b/lib/pg_objects/manager.rb
@@ -63,7 +63,9 @@ class PgObjects::Manager
   end
 
   def find_object(dep_name)
-    result = objects.select { |obj| [obj.name, obj.full_name, obj.object_name].compact.include? dep_name }
+    result = objects.select do |obj|
+      [obj.name, obj.full_name, obj.object_name, obj.qualified_object_name].compact.include?(dep_name)
+    end
 
     raise PgObjects::AmbiguousDependencyError, dep_name if result.size > 1
     raise PgObjects::DependencyNotExistError, dep_name if result.empty?

--- a/lib/pg_objects/parsed_object/aggregate.rb
+++ b/lib/pg_objects/parsed_object/aggregate.rb
@@ -3,6 +3,12 @@
 #
 class PgObjects::ParsedObject::Aggregate < PgObjects::ParsedObject::Base
   def name
-    extract_name { stmt.define_stmt.defnames[0].string.sval }
+    extract_name { stmt.define_stmt.defnames.last.string.sval }
+  end
+
+  private
+
+  def schema
+    extract_name { qualifier(stmt.define_stmt.defnames) }
   end
 end

--- a/lib/pg_objects/parsed_object/base.rb
+++ b/lib/pg_objects/parsed_object/base.rb
@@ -10,9 +10,28 @@ class PgObjects::ParsedObject::Base
     raise NotImplementedError
   end
 
+  # Schema-qualified name (+schema.name+) when a schema is present, otherwise
+  # the same as +name+. Used to disambiguate same-named objects across schemas.
+  def qualified_name
+    schema_name = schema
+    schema_name && !schema_name.empty? ? "#{schema_name}.#{name}" : name
+  end
+
   private
 
   attr_reader :stmt
+
+  # Schema of the object, or nil when unqualified. Subclasses that carry a
+  # schema override this; the rest inherit the unqualified default.
+  def schema
+    nil
+  end
+
+  # Returns the schema element of a pg_query name list (e.g. funcname,
+  # defnames) when the name is qualified (+schema.name+), otherwise nil.
+  def qualifier(list)
+    list[-2].string.sval if list.size > 1
+  end
 
   # Wraps name extraction so a malformed statement (nil field, empty array)
   # surfaces an explicit error with context. Only NoMethodErrors from

--- a/lib/pg_objects/parsed_object/conversion.rb
+++ b/lib/pg_objects/parsed_object/conversion.rb
@@ -3,6 +3,12 @@
 #
 class PgObjects::ParsedObject::Conversion < PgObjects::ParsedObject::Base
   def name
-    extract_name { stmt.create_conversion_stmt.conversion_name[0].string.sval }
+    extract_name { stmt.create_conversion_stmt.conversion_name.last.string.sval }
+  end
+
+  private
+
+  def schema
+    extract_name { qualifier(stmt.create_conversion_stmt.conversion_name) }
   end
 end

--- a/lib/pg_objects/parsed_object/function.rb
+++ b/lib/pg_objects/parsed_object/function.rb
@@ -3,6 +3,12 @@
 #
 class PgObjects::ParsedObject::Function < PgObjects::ParsedObject::Base
   def name
-    extract_name { stmt.create_function_stmt.funcname[0].string.sval }
+    extract_name { stmt.create_function_stmt.funcname.last.string.sval }
+  end
+
+  private
+
+  def schema
+    extract_name { qualifier(stmt.create_function_stmt.funcname) }
   end
 end

--- a/lib/pg_objects/parsed_object/materialized_view.rb
+++ b/lib/pg_objects/parsed_object/materialized_view.rb
@@ -5,4 +5,10 @@ class PgObjects::ParsedObject::MaterializedView < PgObjects::ParsedObject::Base
   def name
     extract_name { stmt.create_table_as_stmt.into.rel.relname }
   end
+
+  private
+
+  def schema
+    extract_name { stmt.create_table_as_stmt.into.rel.schemaname }
+  end
 end

--- a/lib/pg_objects/parsed_object/operator.rb
+++ b/lib/pg_objects/parsed_object/operator.rb
@@ -3,6 +3,12 @@
 #
 class PgObjects::ParsedObject::Operator < PgObjects::ParsedObject::Base
   def name
-    extract_name { stmt.define_stmt.defnames[0].string.sval }
+    extract_name { stmt.define_stmt.defnames.last.string.sval }
+  end
+
+  private
+
+  def schema
+    extract_name { qualifier(stmt.define_stmt.defnames) }
   end
 end

--- a/lib/pg_objects/parsed_object/operator_class.rb
+++ b/lib/pg_objects/parsed_object/operator_class.rb
@@ -3,6 +3,12 @@
 #
 class PgObjects::ParsedObject::OperatorClass < PgObjects::ParsedObject::Base
   def name
-    extract_name { stmt.create_op_class_stmt.opclassname[0].string.sval }
+    extract_name { stmt.create_op_class_stmt.opclassname.last.string.sval }
+  end
+
+  private
+
+  def schema
+    extract_name { qualifier(stmt.create_op_class_stmt.opclassname) }
   end
 end

--- a/lib/pg_objects/parsed_object/table.rb
+++ b/lib/pg_objects/parsed_object/table.rb
@@ -5,4 +5,10 @@ class PgObjects::ParsedObject::Table < PgObjects::ParsedObject::Base
   def name
     extract_name { stmt.create_stmt.relation.relname }
   end
+
+  private
+
+  def schema
+    extract_name { stmt.create_stmt.relation.schemaname }
+  end
 end

--- a/lib/pg_objects/parsed_object/text_search_parser.rb
+++ b/lib/pg_objects/parsed_object/text_search_parser.rb
@@ -3,6 +3,12 @@
 #
 class PgObjects::ParsedObject::TextSearchParser < PgObjects::ParsedObject::Base
   def name
-    extract_name { stmt.define_stmt.defnames[0].string.sval }
+    extract_name { stmt.define_stmt.defnames.last.string.sval }
+  end
+
+  private
+
+  def schema
+    extract_name { qualifier(stmt.define_stmt.defnames) }
   end
 end

--- a/lib/pg_objects/parsed_object/text_search_template.rb
+++ b/lib/pg_objects/parsed_object/text_search_template.rb
@@ -3,6 +3,12 @@
 #
 class PgObjects::ParsedObject::TextSearchTemplate < PgObjects::ParsedObject::Base
   def name
-    extract_name { stmt.define_stmt.defnames[0].string.sval }
+    extract_name { stmt.define_stmt.defnames.last.string.sval }
+  end
+
+  private
+
+  def schema
+    extract_name { qualifier(stmt.define_stmt.defnames) }
   end
 end

--- a/lib/pg_objects/parsed_object/type.rb
+++ b/lib/pg_objects/parsed_object/type.rb
@@ -5,4 +5,10 @@ class PgObjects::ParsedObject::Type < PgObjects::ParsedObject::Base
   def name
     extract_name { stmt.composite_type_stmt.typevar.relname }
   end
+
+  private
+
+  def schema
+    extract_name { stmt.composite_type_stmt.typevar.schemaname }
+  end
 end

--- a/lib/pg_objects/parsed_object/view.rb
+++ b/lib/pg_objects/parsed_object/view.rb
@@ -5,4 +5,10 @@ class PgObjects::ParsedObject::View < PgObjects::ParsedObject::Base
   def name
     extract_name { stmt.view_stmt.view.relname }
   end
+
+  private
+
+  def schema
+    extract_name { stmt.view_stmt.view.schemaname }
+  end
 end

--- a/lib/pg_objects/parser.rb
+++ b/lib/pg_objects/parser.rb
@@ -36,6 +36,13 @@ class PgObjects::Parser
     nil
   end
 
+  def fetch_qualified_object_name
+    parse_query
+    parsed_object.qualified_name
+  rescue PgQuery::ParseError, PgObjects::UnknownObjectTypeError
+    nil
+  end
+
   private
 
   attr_reader :parsed

--- a/lib/pg_objects/parser.rb
+++ b/lib/pg_objects/parser.rb
@@ -20,6 +20,8 @@ class PgObjects::Parser
 
   def load(source)
     @source = source
+    @parsed = nil
+    @parsed_object = nil
     self
   end
 
@@ -30,14 +32,12 @@ class PgObjects::Parser
   end
 
   def fetch_object_name
-    parse_query
     parsed_object.name
   rescue PgQuery::ParseError, PgObjects::UnknownObjectTypeError
     nil
   end
 
   def fetch_qualified_object_name
-    parse_query
     parsed_object.qualified_name
   rescue PgQuery::ParseError, PgObjects::UnknownObjectTypeError
     nil
@@ -45,14 +45,14 @@ class PgObjects::Parser
 
   private
 
-  attr_reader :parsed
-
-  def parse_query
-    @parsed = PgQuery.parse(@source)
+  # Parse once per loaded source; both fetch_* methods reuse the result and
+  # +load+ clears it, so a new source is always reparsed (no stale cache).
+  def parsed
+    @parsed ||= PgQuery.parse(@source)
   end
 
   def parsed_object
-    parsed_object_factory.create_object(parsed)
+    @parsed_object ||= parsed_object_factory.create_object(parsed)
   end
 
   def fetch_dependencies

--- a/spec/integration/manager_spec.rb
+++ b/spec/integration/manager_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe 'Manager integration with real fixtures' do
   end
 
   before do
+    FileUtils.rm_rf(integration_path) # isolate each example's fixture set
+
     allow(ar).to receive(:connection) { connection }
     allow(connection).to receive(:adapter_name).and_return('PostgreSQL')
     allow(connection).to receive(:execute) { |sql| executed << sql }
@@ -41,6 +43,28 @@ RSpec.describe 'Manager integration with real fixtures' do
       manager.load_files(:before).create_objects
 
       expect(executed).to eq([sql_d, sql_c, sql_b, sql_a])
+    end
+  end
+
+  context 'with same-named objects in different schemas' do
+    let(:sql_app) { "CREATE FUNCTION app.thing() RETURNS integer AS $$ SELECT 1; $$ LANGUAGE sql;\n" }
+    let(:sql_audit) { "CREATE FUNCTION audit.thing() RETURNS integer AS $$ SELECT 1; $$ LANGUAGE sql;\n" }
+    let(:sql_consumer) do
+      "--!depends_on app.thing\nCREATE FUNCTION consumer() RETURNS integer AS $$ SELECT 1; $$ LANGUAGE sql;\n"
+    end
+
+    before do
+      # Consumer loads first (alphabetical glob) so the schema-qualified
+      # directive — not file order — must drive resolution of app.thing.
+      create_file_with('integration', '1_consumer.sql', sql_consumer)
+      create_file_with('integration', '2_app_thing.sql', sql_app)
+      create_file_with('integration', '3_audit_thing.sql', sql_audit)
+    end
+
+    it 'resolves the schema-qualified dependency unambiguously and in order' do
+      manager.load_files(:before).create_objects
+
+      expect(executed).to eq([sql_app, sql_consumer, sql_audit])
     end
   end
 

--- a/spec/pg_objects/manager_spec.rb
+++ b/spec/pg_objects/manager_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe PgObjects::Manager do
       name: '',
       full_name: '',
       object_name: '',
+      qualified_object_name: '',
       sql_query: ''
     )
   end
@@ -131,12 +132,13 @@ RSpec.describe PgObjects::Manager do
       let(:db_object_class) do
         Class.new do
           attr_accessor :status, :name, :dependencies, :sql_query
-          attr_reader :full_name, :object_name
+          attr_reader :full_name, :object_name, :qualified_object_name
 
           def initialize(name:, dependencies: [], sql_query: '')
             @name = name
             @full_name = name
             @object_name = name
+            @qualified_object_name = name
             @dependencies = dependencies
             @sql_query = sql_query
             @status = :new
@@ -198,12 +200,13 @@ RSpec.describe PgObjects::Manager do
       let(:db_object_class) do
         Class.new do
           attr_accessor :status, :name, :dependencies, :sql_query
-          attr_reader :full_name, :object_name
+          attr_reader :full_name, :object_name, :qualified_object_name
 
           def initialize(name:, sql_query: '')
             @name = name
             @full_name = name
             @object_name = name
+            @qualified_object_name = name
             @dependencies = []
             @sql_query = sql_query
             @status = :new

--- a/spec/pg_objects/parsed_object/qualified_name_spec.rb
+++ b/spec/pg_objects/parsed_object/qualified_name_spec.rb
@@ -1,0 +1,43 @@
+RSpec.describe 'ParsedObject qualified_name' do # rubocop:disable RSpec/DescribeClass
+  subject(:parsed_object) { PgObjects::ParsedObjectFactory.create_object(PgQuery.parse(source)) }
+
+  context 'with a schema-qualified relation (table)' do
+    let(:source) { 'CREATE TABLE myschema.users (id INT);' }
+
+    it 'exposes the unqualified name' do
+      expect(parsed_object.name).to eq('users')
+    end
+
+    it 'exposes the schema-qualified name' do
+      expect(parsed_object.qualified_name).to eq('myschema.users')
+    end
+  end
+
+  context 'with an unqualified relation (table)' do
+    let(:source) { 'CREATE TABLE users (id INT);' }
+
+    it 'falls back to the bare name for qualified_name' do
+      expect(parsed_object.qualified_name).to eq('users')
+    end
+  end
+
+  context 'with a schema-qualified list name (function)' do
+    let(:source) { 'CREATE FUNCTION app.calc(a INTEGER) RETURNS INTEGER AS $$ SELECT 1; $$ LANGUAGE sql;' }
+
+    it 'exposes the unqualified name' do
+      expect(parsed_object.name).to eq('calc')
+    end
+
+    it 'exposes the schema-qualified name' do
+      expect(parsed_object.qualified_name).to eq('app.calc')
+    end
+  end
+
+  context 'with an unqualified list name (function)' do
+    let(:source) { 'CREATE FUNCTION calc(a INTEGER) RETURNS INTEGER AS $$ SELECT 1; $$ LANGUAGE sql;' }
+
+    it 'falls back to the bare name for qualified_name' do
+      expect(parsed_object.qualified_name).to eq('calc')
+    end
+  end
+end


### PR DESCRIPTION
- Introduced `qualified_object_name` attribute in `DbObject` and updated its initialization.
- Enhanced object selection in `Manager` to include `qualified_object_name`.
- Implemented `qualified_name` method in base parsed object class to return schema-qualified names.
- Updated individual parsed object classes (Aggregate, Conversion, Function, MaterializedView, Operator, OperatorClass, Table, TextSearchParser, TextSearchTemplate, Type, View) to support schema extraction.
- Added integration tests to verify correct resolution of schema-qualified dependencies.
- Created new specs for `qualified_name` functionality.