### PR TITLE
Replace Try-chain type dispatch with hash lookup

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,6 @@ PATH
       dry-auto_inject (~> 1)
       dry-configurable (~> 1)
       dry-container (= 0.11.0)
-      dry-monads (~> 1.6)
       memery (>= 1.5, < 1.9)
       pg_query (>= 5, < 7)
       railties (>= 4, < 9)
@@ -80,10 +79,6 @@ GEM
     dry-core (1.2.0)
       concurrent-ruby (~> 1.0)
       logger
-      zeitwerk (~> 2.6)
-    dry-monads (1.10.0)
-      concurrent-ruby (~> 1.0)
-      dry-core (~> 1.1)
       zeitwerk (~> 2.6)
     erb (6.0.4)
     erubi (1.13.1)

--- a/lib/pg_objects.rb
+++ b/lib/pg_objects.rb
@@ -14,7 +14,6 @@ require 'pg_objects/railtie' if defined?(Rails)
 require 'dry-configurable'
 require 'dry-container'
 require 'dry-auto_inject'
-require 'dry/monads'
 require 'memery'
 
 require 'pg_objects/container'

--- a/lib/pg_objects/parsed_object_factory.rb
+++ b/lib/pg_objects/parsed_object_factory.rb
@@ -2,23 +2,23 @@
 # Returns an object of the respective class based on the provided parsed query
 #
 class PgObjects::ParsedObjectFactory
-  include Dry::Monads[:try, :result]
+  DISPATCH = {
+    composite_type_stmt: PgObjects::ParsedObject::Type,
+    create_conversion_stmt: PgObjects::ParsedObject::Conversion,
+    create_event_trig_stmt: PgObjects::ParsedObject::EventTrigger,
+    create_function_stmt: PgObjects::ParsedObject::Function,
+    create_op_class_stmt: PgObjects::ParsedObject::OperatorClass,
+    create_stmt: PgObjects::ParsedObject::Table,
+    create_trig_stmt: PgObjects::ParsedObject::Trigger,
+    view_stmt: PgObjects::ParsedObject::View
+  }.freeze
 
-  SUPPORTED_TYPES = %i[
-    aggregate
-    conversion
-    event_trigger
-    function
-    materialized_view
-    operator
-    operator_class
-    table
-    text_search_parser
-    text_search_template
-    trigger
-    type
-    view
-  ].freeze
+  DEFINE_STMT_DISPATCH = {
+    OBJECT_AGGREGATE: PgObjects::ParsedObject::Aggregate,
+    OBJECT_OPERATOR: PgObjects::ParsedObject::Operator,
+    OBJECT_TSPARSER: PgObjects::ParsedObject::TextSearchParser,
+    OBJECT_TSTEMPLATE: PgObjects::ParsedObject::TextSearchTemplate
+  }.freeze
 
   def self.create_object(input_data)
     new(input_data).create_object
@@ -38,72 +38,17 @@ class PgObjects::ParsedObjectFactory
   attr_reader :stmt, :input_data
 
   def determine_class
-    SUPPORTED_TYPES.each do |type|
-      return class_for(type) if send("#{type}?")
+    dispatch_class || raise(PgObjects::UnknownObjectTypeError, "unknown object type: #{stmt.node}")
+  end
+
+  def dispatch_class
+    case stmt.node
+    when :define_stmt
+      DEFINE_STMT_DISPATCH[stmt.define_stmt.kind]
+    when :create_table_as_stmt
+      PgObjects::ParsedObject::MaterializedView if stmt.create_table_as_stmt.objtype == :OBJECT_MATVIEW
+    else
+      DISPATCH[stmt.node]
     end
-
-    raise PgObjects::UnknownObjectTypeError, "unknown object type: #{stmt.node}"
-  end
-
-  def class_for(type)
-    "PgObjects::ParsedObject::#{type.to_s.classify}".constantize
-  end
-
-  def aggregate?
-    try_check_get_result { stmt.define_stmt.kind == :OBJECT_AGGREGATE }
-  end
-
-  def conversion?
-    try_check_get_result { stmt.create_conversion_stmt.conversion_name.present? }
-  end
-
-  def event_trigger?
-    try_check_get_result { stmt.create_event_trig_stmt.trigname.present? }
-  end
-
-  def function?
-    try_check_get_result { stmt.create_function_stmt.funcname.present? }
-  end
-
-  def materialized_view?
-    try_check_get_result { stmt.create_table_as_stmt.objtype == :OBJECT_MATVIEW }
-  end
-
-  def operator_class?
-    try_check_get_result { stmt.create_op_class_stmt.opclassname.present? }
-  end
-
-  def operator?
-    try_check_get_result { stmt.define_stmt.kind == :OBJECT_OPERATOR }
-  end
-
-  def table?
-    try_check_get_result { stmt.create_stmt.table_elts.present? }
-  end
-
-  def text_search_parser?
-    try_check_get_result { stmt.define_stmt.kind == :OBJECT_TSPARSER }
-  end
-
-  def text_search_template?
-    try_check_get_result { stmt.define_stmt.kind == :OBJECT_TSTEMPLATE }
-  end
-
-  def trigger?
-    try_check_get_result { stmt.create_trig_stmt.trigname.present? }
-  end
-
-  def type?
-    try_check_get_result { stmt.composite_type_stmt.typevar.present? }
-  end
-
-  def view?
-    try_check_get_result { stmt.view_stmt.view.present? }
-  end
-
-  def try_check_get_result(&)
-    result = Try(&).to_result
-
-    result.success? && result.value!
   end
 end

--- a/pg_objects.gemspec
+++ b/pg_objects.gemspec
@@ -47,7 +47,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'dry-auto_inject', '~> 1'
   spec.add_dependency 'dry-configurable', '~> 1'
   spec.add_dependency 'dry-container', '0.11.0'
-  spec.add_dependency 'dry-monads', '~> 1.6'
   spec.add_dependency 'memery', '>= 1.5', '< 1.9'
   spec.add_dependency 'pg_query', '>= 5', '< 7'
   spec.add_dependency 'railties', '>= 4', '< 9'


### PR DESCRIPTION
## Summary

Closes #290

- Removed twelve `Try { ... }.to_result` predicate methods and linear `send` dispatch over `SUPPORTED_TYPES`
- Added explicit frozen `DISPATCH` table keyed on `stmt.node`, plus `DEFINE_STMT_DISPATCH` keyed on `define_stmt.kind` (aggregate/operator/tsparser/tstemplate)
- `create_table_as_stmt` special-cased: matches `MaterializedView` only when `objtype == :OBJECT_MATVIEW`, preserving prior behavior for plain `CREATE TABLE AS`
- No broad `StandardError` rescue anywhere in dispatch
- Dropped `dry-monads` entirely (require + gemspec dependency) — the factory was its only consumer

## Test plan

- Full suite: 156 specs pass
- Rubocop clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)