### PR TITLE
Enable frozen string literal comments and enforce style across the co…

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -222,9 +222,15 @@ Style/ExponentialNotation:
 
 # Checks if there is a magic comment to enforce string literals
 Style/FrozenStringLiteralComment:
-  Enabled: false
+  Enabled: true
+  EnforcedStyle: always
 
 Style/HashAsLastArrayItem:
+  Enabled: true
+
+# Use explicit named block arguments instead of numbered parameters (_1)
+Style/NumberedParameters:
+  EnforcedStyle: disallow
   Enabled: true
 
 Style/HashEachMethods:

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 

--- a/bin/benchmark
+++ b/bin/benchmark
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'bundler/setup'
 require 'active_support/core_ext/string/inflections' # String#classify / #constantize used by the parser

--- a/bin/console
+++ b/bin/console
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'bundler/setup'
 require 'pg_objects'

--- a/lib/generators/pg_objects/install/install_generator.rb
+++ b/lib/generators/pg_objects/install/install_generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ##
 # Creates default directories structure
 class PgObjects::InstallGenerator < Rails::Generators::Base

--- a/lib/pg_objects.rb
+++ b/lib/pg_objects.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'pg_objects/version'
 
 module PgObjects

--- a/lib/pg_objects/config.rb
+++ b/lib/pg_objects/config.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'yaml_configurable'
 
 module PgObjects
@@ -55,7 +57,7 @@ module PgObjects
       'db:migrate:redo' => %i[before after]
     }
 
-    DEFAULT_YAML_PATH = 'config/pg_objects.yml'.freeze
+    DEFAULT_YAML_PATH = 'config/pg_objects.yml'
 
     class << self
       # YAML loading is deferred to the first config access so the path is

--- a/lib/pg_objects/db_object.rb
+++ b/lib/pg_objects/db_object.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ##
 # Represents DB object as it is described in file
 #

--- a/lib/pg_objects/logger.rb
+++ b/lib/pg_objects/logger.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ##
 # Console output with severity levels. Writes to the injected +stream+
 # (default +$stdout+). With +config.silent+ enabled, +info+/+warn+ messages

--- a/lib/pg_objects/manager.rb
+++ b/lib/pg_objects/manager.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ##
 # Manages process to create objects
 #
@@ -42,7 +44,7 @@ class PgObjects::Manager
 
   def create_objects
     build_objects_index
-    within_transaction { objects.each { create_object(_1) } }
+    within_transaction { objects.each { |obj| create_object(obj) } }
   end
 
   def objects

--- a/lib/pg_objects/parsed_object.rb
+++ b/lib/pg_objects/parsed_object.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module PgObjects::ParsedObject # rubocop: disable Style/Documentation
 end
 

--- a/lib/pg_objects/parsed_object/aggregate.rb
+++ b/lib/pg_objects/parsed_object/aggregate.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # AGGREGATE object representation
 #

--- a/lib/pg_objects/parsed_object/base.rb
+++ b/lib/pg_objects/parsed_object/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Base class for parsed objects
 #

--- a/lib/pg_objects/parsed_object/base_type.rb
+++ b/lib/pg_objects/parsed_object/base_type.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Base (scalar) TYPE object representation (CREATE TYPE with I/O functions or
 # a shell CREATE TYPE without attributes) — parsed as a define_stmt.

--- a/lib/pg_objects/parsed_object/conversion.rb
+++ b/lib/pg_objects/parsed_object/conversion.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # CONVERSION object representation
 #

--- a/lib/pg_objects/parsed_object/domain.rb
+++ b/lib/pg_objects/parsed_object/domain.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # DOMAIN object representation (CREATE DOMAIN)
 #

--- a/lib/pg_objects/parsed_object/enum_type.rb
+++ b/lib/pg_objects/parsed_object/enum_type.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # ENUM TYPE object representation (CREATE TYPE ... AS ENUM)
 #

--- a/lib/pg_objects/parsed_object/event_trigger.rb
+++ b/lib/pg_objects/parsed_object/event_trigger.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # EVENT TRIGGER object representation
 #

--- a/lib/pg_objects/parsed_object/extension.rb
+++ b/lib/pg_objects/parsed_object/extension.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # EXTENSION object representation
 #

--- a/lib/pg_objects/parsed_object/function.rb
+++ b/lib/pg_objects/parsed_object/function.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # FUNCTION object representation
 #

--- a/lib/pg_objects/parsed_object/index.rb
+++ b/lib/pg_objects/parsed_object/index.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # INDEX object representation
 #

--- a/lib/pg_objects/parsed_object/materialized_view.rb
+++ b/lib/pg_objects/parsed_object/materialized_view.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # MATERIALIZED VIEW object representation
 #

--- a/lib/pg_objects/parsed_object/operator.rb
+++ b/lib/pg_objects/parsed_object/operator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # OPERATOR object representation
 #

--- a/lib/pg_objects/parsed_object/operator_class.rb
+++ b/lib/pg_objects/parsed_object/operator_class.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # OPERATOR CLASS object representation
 #

--- a/lib/pg_objects/parsed_object/policy.rb
+++ b/lib/pg_objects/parsed_object/policy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # POLICY object representation
 #

--- a/lib/pg_objects/parsed_object/range_type.rb
+++ b/lib/pg_objects/parsed_object/range_type.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # RANGE TYPE object representation (CREATE TYPE ... AS RANGE)
 #

--- a/lib/pg_objects/parsed_object/rule.rb
+++ b/lib/pg_objects/parsed_object/rule.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # RULE object representation
 #

--- a/lib/pg_objects/parsed_object/sequence.rb
+++ b/lib/pg_objects/parsed_object/sequence.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # SEQUENCE object representation
 #

--- a/lib/pg_objects/parsed_object/table.rb
+++ b/lib/pg_objects/parsed_object/table.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # TABLE object representation
 #

--- a/lib/pg_objects/parsed_object/text_search_parser.rb
+++ b/lib/pg_objects/parsed_object/text_search_parser.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # TEXT SEARCH PARSER object representation
 #

--- a/lib/pg_objects/parsed_object/text_search_template.rb
+++ b/lib/pg_objects/parsed_object/text_search_template.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # TEXT SEARCH TEMPLATE object representation
 #

--- a/lib/pg_objects/parsed_object/trigger.rb
+++ b/lib/pg_objects/parsed_object/trigger.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # TRIGGER object representation
 #

--- a/lib/pg_objects/parsed_object/type.rb
+++ b/lib/pg_objects/parsed_object/type.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # TYPE object representation
 #

--- a/lib/pg_objects/parsed_object/view.rb
+++ b/lib/pg_objects/parsed_object/view.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # VIEW object representation
 #

--- a/lib/pg_objects/parsed_object_factory.rb
+++ b/lib/pg_objects/parsed_object_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Returns an object of the respective class based on the provided parsed query
 #

--- a/lib/pg_objects/parser.rb
+++ b/lib/pg_objects/parser.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'pg_query'
 
 ##

--- a/lib/pg_objects/railtie.rb
+++ b/lib/pg_objects/railtie.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ##
 # Brings rake tasks to rails app
 class PgObjects::Railtie < Rails::Railtie

--- a/lib/pg_objects/version.rb
+++ b/lib/pg_objects/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module PgObjects
-  VERSION = '1.4.8'.freeze
+  VERSION = '1.4.8'
 end

--- a/lib/pg_objects/yaml_configurable.rb
+++ b/lib/pg_objects/yaml_configurable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # A module that provides a method to load configuration settings from a YAML file.
 module YamlConfigurable
   # Loads configuration settings from a YAML file.

--- a/lib/tasks/pg_objects_tasks.rake
+++ b/lib/tasks/pg_objects_tasks.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Resolves the connection to run against. Set PG_OBJECTS_CONNECTION_CLASS to
 # the name of an Active Record class (e.g. "AnimalsRecord") to target that
 # class's database in a multi-DB setup; unset, the global connection is used.

--- a/pg_objects.gemspec
+++ b/pg_objects.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 

--- a/spec/benchmark_spec.rb
+++ b/spec/benchmark_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'English'
 require 'shellwords'
 

--- a/spec/integration/manager_spec.rb
+++ b/spec/integration/manager_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe 'Manager integration with real fixtures' do
   include FixtureHelpers
 

--- a/spec/integration/thread_safety_spec.rb
+++ b/spec/integration/thread_safety_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe 'Parsing thread safety' do
   include FixtureHelpers
 

--- a/spec/pg_objects/config_spec.rb
+++ b/spec/pg_objects/config_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'fileutils'
 require 'pathname'
 require 'tmpdir'

--- a/spec/pg_objects/container_spec.rb
+++ b/spec/pg_objects/container_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe PgObjects::Container do
   describe 'registrations' do
     it 'resolves config to the shared Config.config' do

--- a/spec/pg_objects/db_object_factory_spec.rb
+++ b/spec/pg_objects/db_object_factory_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe PgObjects::DbObjectFactory do
   subject(:factory) { described_class.new }
 

--- a/spec/pg_objects/db_object_spec.rb
+++ b/spec/pg_objects/db_object_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe PgObjects::DbObject do
   include FixtureHelpers
 

--- a/spec/pg_objects/logger_spec.rb
+++ b/spec/pg_objects/logger_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'stringio'
 
 RSpec.describe PgObjects::Logger do

--- a/spec/pg_objects/manager_spec.rb
+++ b/spec/pg_objects/manager_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe PgObjects::Manager do
   include FixtureHelpers
 

--- a/spec/pg_objects/parsed_object/aggregate_spec.rb
+++ b/spec/pg_objects/parsed_object/aggregate_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'shared/context'
 require_relative 'shared/examples'
 

--- a/spec/pg_objects/parsed_object/base_spec.rb
+++ b/spec/pg_objects/parsed_object/base_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe PgObjects::ParsedObject::Base do
   subject(:base) { described_class.new(stmt) }
 

--- a/spec/pg_objects/parsed_object/base_type_spec.rb
+++ b/spec/pg_objects/parsed_object/base_type_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'shared/context'
 require_relative 'shared/examples'
 

--- a/spec/pg_objects/parsed_object/conversion_spec.rb
+++ b/spec/pg_objects/parsed_object/conversion_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'shared/context'
 require_relative 'shared/examples'
 

--- a/spec/pg_objects/parsed_object/domain_spec.rb
+++ b/spec/pg_objects/parsed_object/domain_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'shared/context'
 require_relative 'shared/examples'
 

--- a/spec/pg_objects/parsed_object/enum_type_spec.rb
+++ b/spec/pg_objects/parsed_object/enum_type_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'shared/context'
 require_relative 'shared/examples'
 

--- a/spec/pg_objects/parsed_object/event_trigger_spec.rb
+++ b/spec/pg_objects/parsed_object/event_trigger_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'shared/context'
 require_relative 'shared/examples'
 

--- a/spec/pg_objects/parsed_object/extension_spec.rb
+++ b/spec/pg_objects/parsed_object/extension_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'shared/context'
 require_relative 'shared/examples'
 

--- a/spec/pg_objects/parsed_object/function_spec.rb
+++ b/spec/pg_objects/parsed_object/function_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'shared/context'
 require_relative 'shared/examples'
 

--- a/spec/pg_objects/parsed_object/index_spec.rb
+++ b/spec/pg_objects/parsed_object/index_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'shared/context'
 require_relative 'shared/examples'
 

--- a/spec/pg_objects/parsed_object/materialized_view_spec.rb
+++ b/spec/pg_objects/parsed_object/materialized_view_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'shared/context'
 require_relative 'shared/examples'
 

--- a/spec/pg_objects/parsed_object/operator_class_spec.rb
+++ b/spec/pg_objects/parsed_object/operator_class_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'shared/context'
 require_relative 'shared/examples'
 

--- a/spec/pg_objects/parsed_object/operator_spec.rb
+++ b/spec/pg_objects/parsed_object/operator_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'shared/context'
 require_relative 'shared/examples'
 

--- a/spec/pg_objects/parsed_object/policy_spec.rb
+++ b/spec/pg_objects/parsed_object/policy_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'shared/context'
 require_relative 'shared/examples'
 

--- a/spec/pg_objects/parsed_object/qualified_name_spec.rb
+++ b/spec/pg_objects/parsed_object/qualified_name_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe 'ParsedObject qualified_name' do # rubocop:disable RSpec/DescribeClass
   subject(:parsed_object) { PgObjects::ParsedObjectFactory.create_object(PgQuery.parse(source)) }
 

--- a/spec/pg_objects/parsed_object/range_type_spec.rb
+++ b/spec/pg_objects/parsed_object/range_type_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'shared/context'
 require_relative 'shared/examples'
 

--- a/spec/pg_objects/parsed_object/rule_spec.rb
+++ b/spec/pg_objects/parsed_object/rule_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'shared/context'
 require_relative 'shared/examples'
 

--- a/spec/pg_objects/parsed_object/sequence_spec.rb
+++ b/spec/pg_objects/parsed_object/sequence_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'shared/context'
 require_relative 'shared/examples'
 

--- a/spec/pg_objects/parsed_object/shared/context.rb
+++ b/spec/pg_objects/parsed_object/shared/context.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.shared_context 'with parsed object context' do
   include SourceHelpers
 

--- a/spec/pg_objects/parsed_object/shared/examples.rb
+++ b/spec/pg_objects/parsed_object/shared/examples.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.shared_examples 'parsed object' do
   it 'has a proper object name' do
     expect(subject.name).to eq(object_name)

--- a/spec/pg_objects/parsed_object/table_spec.rb
+++ b/spec/pg_objects/parsed_object/table_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'shared/context'
 require_relative 'shared/examples'
 

--- a/spec/pg_objects/parsed_object/text_search_parser_spec.rb
+++ b/spec/pg_objects/parsed_object/text_search_parser_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'shared/context'
 require_relative 'shared/examples'
 

--- a/spec/pg_objects/parsed_object/text_search_template_spec.rb
+++ b/spec/pg_objects/parsed_object/text_search_template_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'shared/context'
 require_relative 'shared/examples'
 

--- a/spec/pg_objects/parsed_object/trigger_spec.rb
+++ b/spec/pg_objects/parsed_object/trigger_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'shared/context'
 require_relative 'shared/examples'
 

--- a/spec/pg_objects/parsed_object/type_spec.rb
+++ b/spec/pg_objects/parsed_object/type_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'shared/context'
 require_relative 'shared/examples'
 

--- a/spec/pg_objects/parsed_object/view_spec.rb
+++ b/spec/pg_objects/parsed_object/view_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'shared/context'
 require_relative 'shared/examples'
 

--- a/spec/pg_objects/parsed_object_factory_spec.rb
+++ b/spec/pg_objects/parsed_object_factory_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe PgObjects::ParsedObjectFactory do
   using RSpec::Parameterized::TableSyntax
 

--- a/spec/pg_objects/parser_spec.rb
+++ b/spec/pg_objects/parser_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe PgObjects::Parser do
   include SourceHelpers
 

--- a/spec/pg_objects/railtie_spec.rb
+++ b/spec/pg_objects/railtie_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails/railtie'
 require 'rake'
 require 'pg_objects/railtie'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler/setup'
 require 'active_record'
 require 'byebug'

--- a/spec/support/fixture_helpers.rb
+++ b/spec/support/fixture_helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'fileutils'
 
 module FixtureHelpers

--- a/spec/support/source_helpers.rb
+++ b/spec/support/source_helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SourceHelpers
   def table_source(name = 'no_reason_for_this')
     <<~SQL

--- a/spec/tasks/pg_objects_tasks_spec.rb
+++ b/spec/tasks/pg_objects_tasks_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rake'
 
 RSpec.describe 'pg_objects rake hooks' do # rubocop:disable RSpec/DescribeClass


### PR DESCRIPTION
…debase; disallow numbered parameters in favor of explicit block arguments. Update RuboCop configuration and add frozen string literal comments to all relevant files.